### PR TITLE
Add support for # sign comment character

### DIFF
--- a/grammars/lcb.cson
+++ b/grammars/lcb.cson
@@ -11,6 +11,9 @@
     'include': '#comment-line'
   }
   {
+    'include': '#comment-number-sign'
+  }
+  {
     'include': '#comment-block'
   }
   {
@@ -92,6 +95,14 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.comment.double-dash.lcb'
+    'end': '\\n'
+    'name': 'comment.line.lcb'
+
+  'comment-number-sign':
+    'begin': '#'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.comment.number-sign.lcb'
     'end': '\\n'
     'name': 'comment.line.lcb'
 


### PR DESCRIPTION
Add support for the # sign comment character as a single line type of
comment for LiveCode builder syntax.

Note: This change does not actually colorize the commented lines to match the LiveCode IDE script editor. That task was done by editing my local styles.less file. It isn’t clear to me whether these colorization changes can be packaged into the language support files - so I didn’t do that.
