### PR TITLE
add // as an LCB supported comment

### DIFF
--- a/grammars/lcb.cson
+++ b/grammars/lcb.cson
@@ -88,7 +88,7 @@
 'repository':
 
   'comment-line':
-    'begin': '--'
+    'begin': '--|//'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.comment.double-dash.lcb'


### PR DESCRIPTION
Updated the comment-line regex to support either — or // as comment
lines for LCB code in the lcb.cson file.
